### PR TITLE
Include EOL distros with rosdep

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ runs:
         if ! [ -d /etc/ros/rosdep/sources.list.d ]; then
           rosdep init
         fi
-        rosdep update
+        rosdep update --include-eol-distros
 
     - name: Install ccache depends
       if: inputs.ccache-enabled == 'true' && runner.os == 'Linux'


### PR DESCRIPTION
Updates call to `rosdep` to include EOL distros with rosdep to support Foxy