### PR TITLE
Call apt update before running rosdep

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -122,6 +122,7 @@ runs:
         if [ $? -ge 1 ]; then return 1; fi
         cd $GITHUB_WORKSPACE/upstream_ws
         if [[ "${{ inputs.rosdep-enabled }}" == "true" ]] && [[ "${{ runner.os }}" == "Linux" ]]; then
+          apt update -y -qq
           rosdep install --from-paths src -iry ${{ inputs.rosdep-install-args }}
         fi
         if [[ "${{ inputs.ccache-enabled }}" == "true" ]] && [[ "${{ runner.os }}" == "Linux" ]]; then
@@ -141,6 +142,7 @@ runs:
         fi
         cd $GITHUB_WORKSPACE/${{ inputs.target-path }}/../
         if [[ "${{ inputs.rosdep-enabled }}" == "true" ]]; then
+          apt update -y -qq
           rosdep install --from-paths src -iry ${{ inputs.rosdep-install-args }}
         fi
         if [[ "${{ inputs.ccache-enabled }}" == "true" ]]; then


### PR DESCRIPTION
I've run into some issues recently where not calling `apt update` before `rosdep install` prevents packages (particularly new packages in the ROS ecosystem) from being found by `rosdep`. This change should prevent that from happening