### PR TITLE
Support builds on 24.04

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,9 +58,7 @@ runs:
       run: |
         apt update
         apt upgrade -y
-        apt install -y cmake curl git python3 python3-pip
-        python3 -m pip install vcstool -q
-        python3 -m pip install colcon-common-extensions -q
+        apt install -y cmake curl git python3-vcstool python3-colcon-common-extensions
 
     - name: Install colcon depends (Windows)
       if: runner.os == 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -52,13 +52,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install colcon depends (Linux)
+    - name: Install base dependencies (Linux)
       if: runner.os == 'Linux'
       shell: bash
       run: |
-        apt update
+        apt update -y -qq
         apt upgrade -y
-        apt install -y cmake curl git python3-vcstool python3-colcon-common-extensions
+        apt install -y cmake curl git python3 python3-pip
 
     - name: Install colcon depends (Windows)
       if: runner.os == 'Windows'
@@ -74,13 +74,20 @@ runs:
       run: |
         curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
-        apt update -qq
+        apt update -y -qq
+
+    - name: Install ROS infrastructure dependencies (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        apt update -y -qq
+        apt upgrade -y -qq
+        apt install -y -qq python3-vcstool python3-colcon-common-extensions python3-rosdep
 
     - name: Install rosdep depends
       if: inputs.rosdep-enabled == 'true' && runner.os == 'Linux'
       shell: bash
       run: |
-        python3 -m pip install rosdep -q
         if ! [ -d /etc/ros/rosdep/sources.list.d ]; then
           rosdep init
         fi

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
       run: |
         apt update
         apt upgrade -y
-        apt install -y cmake curl git python3 python3-distutils python3-pip
+        apt install -y cmake curl git python3 python3-pip
         python3 -m pip install vcstool -q
         python3 -m pip install colcon-common-extensions -q
 


### PR DESCRIPTION
In Ubuntu 24.04, it appears you are no longer allowed to install packages globally using `pip`, so commands like `python3 -m pip install rosdep` do not work any more. This PR changes the install of these dependencies to use `apt` instead, which appears to work correctly. The potential downside is that you need to add the ROS sources first to be able to install packages like `python3-vcstool`, etc.

Addresses #10 