### PR TITLE
Reintroduce `ros-enabled`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@
     rosdep-enabled: 'true'
     # Additional args to pass to rosdep install (optional, default: '-r')
     rosdep-install-args: '-r'
-    # Indicate if ROS PPA should be added (optional, default: 'false')
-    ros-enabled: 'false'
+    # Indicate if ROS PPA should be added (optional, default: 'false').
+    # The ROS PPA must be added if the Linux OS on which this action runs does not already contain a ROS distro.
+    # The ROS PPA should not be added if the Linux OS already contains a ROS distro (e.g., ROS Docker image)
+    add-ros-ppa: 'false'
     # The relative path to the vcs repos file (optional, default: '')
     vcs-file: 'dependencies.repos'
     # Additional args to pass to colcon build for upstream workspace (optional, default: '')

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ``` yaml
-- uses: tesseract-robotics/colcon-action@v5
+- uses: tesseract-robotics/colcon-action@v9
   with:
     # Script that runs before anything else in build steps (optional, default: '')
     before-script: ''

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Usage
 
 ``` yaml
-- uses: tesseract-robotics/colcon-action@v8
+- uses: tesseract-robotics/colcon-action@v5
   with:
     # Script that runs before anything else in build steps (optional, default: '')
     before-script: ''
@@ -17,6 +17,8 @@
     rosdep-enabled: 'true'
     # Additional args to pass to rosdep install (optional, default: '-r')
     rosdep-install-args: '-r'
+    # Indicate if ROS PPA should be added (optional, default: 'false')
+    ros-enabled: 'false'
     # The relative path to the vcs repos file (optional, default: '')
     vcs-file: 'dependencies.repos'
     # Additional args to pass to colcon build for upstream workspace (optional, default: '')

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
   add-ros-ppa:
     description: "Indicate if ROS PPA should be added (optional)"
     required: false
-    default: 'false'
+    default: 'true'
   vcs-file:
     description: "The relative path to the vcs repos file (optional)"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: "Additional args to pass to rosdep install (optional)"
     required: false
     default: '-r'
+  ros-enabled:
+    description: "Indicate if ROS PPA should be added (optional)"
+    required: false
+    default: 'false'
   vcs-file:
     description: "The relative path to the vcs repos file (optional)"
     required: false

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     description: "Additional args to pass to rosdep install (optional)"
     required: false
     default: '-r'
-  ros-enabled:
+  add-ros-ppa:
     description: "Indicate if ROS PPA should be added (optional)"
     required: false
     default: 'false'
@@ -69,7 +69,7 @@ runs:
         python3 -m pip install ninja -q
 
     - name: Install ROS/Colcon PPA (Linux)
-      if: inputs.ros-enabled == 'true' && runner.os == 'Linux'
+      if: inputs.add-ros-ppa == 'true' && runner.os == 'Linux'
       shell: bash
       run: |
         curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg

--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
         python3 -m pip install ninja -q
 
     - name: Install ROS/Colcon PPA (Linux)
-      if: runner.os == 'Linux'
+      if: inputs.ros-enabled == 'true' && runner.os == 'Linux'
       shell: bash
       run: |
         curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg


### PR DESCRIPTION
I have an issue [here](https://github.com/ros-industrial/industrial_calibration_ros2/actions/runs/9994024882/job/27622836011?pr=7) where force adding the ROS PPA to a Docker image that already has ROS installed causes the CI job to fail.

```
Setting up curl (8.5.0-2ubuntu10.1) ...
Run curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

E: Conflicting values set for option Signed-By regarding source http://packages.ros.org/ros2/ubuntu/ noble: /usr/share/keyrings/ros2-latest-archive-keyring.gpg != /usr/share/keyrings/ros-archive-keyring.gpg
E: The list of sources could not be read.
```

This PR reintroduces the `ros-enabled` input under the name `add-ros-ppa` and adds some documentation about when you should and should not use this input