### PR TITLE
Changed method for installing ROS2 based on recent signing key migration

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,9 +72,11 @@ runs:
       if: inputs.add-ros-ppa == 'true' && runner.os == 'Linux'
       shell: bash
       run: |
-        curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
         apt update -y -qq
+        apt install curl -y -qq
+        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
+        curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" # If using Ubuntu derivates use $UBUNTU_CODENAME
+        apt install /tmp/ros2-apt-source.deb
 
     - name: Install colcon depends (Linux)
       if: runner.os == 'Linux'


### PR DESCRIPTION
Changes per commit message to install ROS2 based on new instructions after the [signing key migration](https://discourse.ros.org/t/ros-signing-key-migration-guide/43937)